### PR TITLE
Small fixes with Transformers models

### DIFF
--- a/tests/huggingface/test_module_huggingface.py
+++ b/tests/huggingface/test_module_huggingface.py
@@ -6,6 +6,8 @@
 
 from urllib.error import HTTPError
 
+import pytest
+
 import pytorch_lightning as pl
 import torch
 import torchaudio
@@ -84,3 +86,11 @@ def test_quantized_script_module():
     torchaudio_transcription = scripted.predict(fake_input)
 
     assert fake_transcription[0] == torchaudio_transcription[0]
+
+
+@mark_slow
+def test_pretrained_without_vocab():
+    with pytest.warns(UserWarning, match="missing"):
+        load_pretrained("facebook/wav2vec2-base-100k-voxpopuli")
+
+

--- a/tests/huggingface/test_module_huggingface.py
+++ b/tests/huggingface/test_module_huggingface.py
@@ -94,3 +94,8 @@ def test_pretrained_without_vocab():
         load_pretrained("facebook/wav2vec2-base-100k-voxpopuli")
 
 
+@mark_slow
+def test_pretrained_problematic_tokens():
+    module = load_pretrained("lgris/wav2vec2-large-xlsr-open-brazilian-portuguese-v2")
+    assert module.text_transform.num_tokens == 44
+    assert module.text_transform.vocab.start_token == None


### PR DESCRIPTION
This PR fixes two issues related to loading pretrained models from the huggingface hub:

- Loading of pretrained-only models, that lack the tokenizer and decoder layer
- Some special checkpoints have new tokens assigned when loading, causing a mismatch between the decoder layer and vocabulary